### PR TITLE
Evolutions of change control in the People lane

### DIFF
--- a/docs/Production_Launch_Platform.md
+++ b/docs/Production_Launch_Platform.md
@@ -1,0 +1,20 @@
+---
+type: post
+---
+# Production Launch Platform
+
+Production launch checklists have been largely automated through purpose-built tooling. Production Readiness Reviews are more efficient due to widespread adoption of standardized platforms which satisfy many requirements out-of-the-box.
+
+## Related Products
+
+## Prerequisites
+
+Self-driven checklist-based launches
+
+## Next
+
+N/A
+
+## Related Terms
+
+* [Production Readiness Review](https://sre.google/sre-book/evolving-sre-engagement-model/#the-prr-model-DVsGhWZ)

--- a/docs/Self_Driven_Checklist_Launches.md
+++ b/docs/Self_Driven_Checklist_Launches.md
@@ -1,0 +1,20 @@
+---
+type: post
+---
+# Self-driven checklist-based launches
+
+Teams are empowered to effect production changes within their area without enforced central oversight. Production readiness checklists and reviews are in use and are increasingly validated locally within the team versus via central governance (CABs). Over time they become goverened through a social contract or honor system, with possible periodic validation. Large changes may still go through a more formal launch process which requires review from one of more central functions -- particularly for areas that are outside of the expertise of the engineering team (e.g. legal, security, and privacy review).
+
+## Related Products
+
+## Prerequisites
+
+Single Central CAB, Centralized Production Changelog
+
+## Next
+
+Production Launch Platform
+
+## Related Terms
+
+* [Production Readiness Review](https://sre.google/sre-book/evolving-sre-engagement-model/#the-prr-model-DVsGhWZ)


### PR DESCRIPTION
Added two new topics. Unclear how to associate them with specific eras in the docs.

Self_Driven_Checklist_Launches.md --> Proactive
Production_Launch_Platform.md --> Autonomic