### PR TITLE
Update Gemfile.lock rexml 3.2.5 to 3.2.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,7 +74,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rexml (3.2.5)
+    rexml (3.2.7)
     rouge (3.30.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)


### PR DESCRIPTION
To fix https://www.ruby-lang.org/en/news/2024/05/16/dos-rexml-cve-2024-35176/

Not really tested YMMV