### PR TITLE
suggestion for "Vanilla DDoS pprotection" page contents

### DIFF
--- a/docs/Vanilla_DDoS_Protection.md
+++ b/docs/Vanilla_DDoS_Protection.md
@@ -1,3 +1,116 @@
----
+# Vanilla DDoS Protection
+
+**Vanilla Distributed Denial-of-Service attack Protection**
+
+**Definition:**
+A Denial-of-Service (DoS) attack is a cyberattack in which a system, server, or network is intentionally overwhelmed with traffic or requests so that it becomes slow or completely unavailable to legitimate users.
+
+A Distributed Denial-of-Service (DDoS) attack is an advanced form of a DoS attack where multiple systems simultaneously flood a target, overwhelming it and making the service unavailable.
+
+“Vanilla” DDoS protection refers to basic, built-in defenses that rely on standard infrastructure and simple controls—without specialized anti-DDoS platforms.
+
+This kind of protection is effective for small to medium threats, but not for large-scale, coordinated DDoS attacks.
+
+**Key Steps:**
+
+1. **Network-level filtering** Firewalls drop obviously invalid or malformed packets, block known bad IP ranges
+
+2. **Rate limiting** Limit requests per IP or per endpoint and prevents simple flooding attacks from overwhelming services
+
+3. **Load balancing** Distributes traffic across multiple servers prevents a single node from becoming a bottleneck
+
+4. **Basic auto-scaling** Infrastructure scales up when traffic increases. That helps to absorb moderate spikes (but not large-scale attacks)
+
+5. **Reverse proxy / CDN (basic usage)** Adds a buffering layer between users and origin servers. Caches static content to reduce load.
+
+6. **Connection limits & timeouts** Limit concurrent connections per client. Drop slow or idle connections (protects against Slowloris-type attacks)
+
+**Benefits:**
+
+- **Low cost (often free or already included)** Uses built-in features of platforms like Amazon Web Services or basic tiers of Cloudflare
+
+- **Easy to implement** Relies on standard components, such as Firewalls, Load balancers, Rate limiting. Can be configured quickly without deep security expertise.
+
+
+**Examples:**
+
+The user request path should look like something this (for AWS stack):
+User → Cloudflare → CloudFront → AWS WAF  → AWS Shield Advanced → LB (L7) → App
+
+
+## Related Tools and Products
+
+**Tools and Products for Vanilla DDoS Protection:**
+
+**1. Cloudflare:**
+
+- [Website](https://www.cloudflare.com/)
+- **Description:** Global Anycast CDN with Automatic always-on L3/L4 volumetric attack mitigation (no manual activation needed).
+
+
+**2. Amazon CloudFront:**
+
+- [Website](https://aws.amazon.com/cloudfront/)
+- **Description:** CDN. Caches static content, reduces load on origin servers. Also provide basic filtering and WAF capabilities.
+
+**3. Google Cloud Armor:**
+
+- [Website](https://cloud.google.com/security/products/armor)
+- **Description:** A web application firewall (WAF) and DDoS protection service built into Google Cloud’s global load balancing infrastructure.
+
+
+**4. Nginx:**
+
+- [Website](https://nginx.org/)
+- **Description:** a high-performance software used as a web server, reverse proxy, load balancer, and HTTP cache. Have built-in rate limiting, IP blacklisting / whitelisting capabilities.
+
+**5. AWS Web Application Firewall:**
+
+- [Website](https://aws.amazon.com/waf/)
+- **Description:** A web application firewall (WAF) that provides basic filtering and WAF capabilities.
+
+
+## Related Terms
+
+**Related Terms to Vanilla DDoS Protection:**
+
+These related terms are often used in conjunction with Vanilla DDoS Protection.
+
+- **Rate limiting** Restricts how many requests a client can make in a given time window to prevent abuse and traffic spikes.
+
+- **Throttling** Gradually slows down excessive traffic instead of blocking it outright, preserving partial service availability.
+
+- **IP filtering / ACLs** Allows or blocks traffic based on IP addresses or ranges using firewall or router rules.
+
+- **Reverse proxy** A proxy service that handles incoming requests and protects backend services.
+
+- **Load balancing** Distributes traffic across multiple servers to avoid overload and improve availability.
+
+- **CDN (Content Delivery Network)** Caches content and absorbs traffic at edge locations (e.g., Cloudflare).
+
+- **Firewall (L3/L4 filtering)** Filters packets at the network level (e.g., iptables, security groups) before they reach applications.
+
+- **Auto-scaling** Automatically adds or removes compute resources based on traffic load to handle spikes.
+
+- **Caching** Stores responses to reduce backend load and improve response time under traffic pressure.
+
+- **Anycast routing** Routes traffic to the nearest or least-loaded data center, helping distribute attack traffic globally.
+
+
+## Prerequisites
+
+Before conducting Vanilla DDoS Protection, it is essential to have the following in place:
+
+**1. Scalable architecture and appropriate infrastructure:**
+- Stateless services where possible
+- multiple instances
+- at least basic Load balancing + Web Application Firewall
+
+
+## What's next?
+
+After conducting Vanilla DDoS Protection, the next steps typically involve implementing Proactive DDoS countermeasures
+
+By following these steps, teams can build on the results of their Proactive Risk and Scaling Analysis to ensure the ongoing reliability, scalability, and resilience of their systems and applications.---
 type: post
 ---

--- a/docs/Vanilla_DDoS_Protection.md
+++ b/docs/Vanilla_DDoS_Protection.md
@@ -34,7 +34,7 @@ This kind of protection is effective for small to medium threats, but not for la
 
 **Examples:**
 
-The user request path should look like something this (for AWS stack):
+The user request path should look something like this (for AWS stack):
 User → Cloudflare → CloudFront → AWS WAF  → AWS Shield Advanced → LB (L7) → App
 
 

--- a/docs/Vanilla_DDoS_Protection.md
+++ b/docs/Vanilla_DDoS_Protection.md
@@ -111,6 +111,7 @@ Before conducting Vanilla DDoS Protection, it is essential to have the following
 
 After conducting Vanilla DDoS Protection, the next steps typically involve implementing Proactive DDoS countermeasures
 
-By following these steps, teams can build on the results of their Proactive Risk and Scaling Analysis to ensure the ongoing reliability, scalability, and resilience of their systems and applications.---
+By following these steps, teams can build on the results of their Proactive Risk and Scaling Analysis to ensure the ongoing reliability, scalability, and resilience of their systems and applications.
+---
 type: post
 ---


### PR DESCRIPTION
Added contents for an empty vanilla DDoS protection page.


BTW, are you sure it belongs to the proactive era? 
Looks to me like it should be part of a reactive era
like this:
"Vanilla DDoS protection" changes proactive era -> reactive era
"Proactive DDoS protection" change autonomic era -> proactive era
Just makes a little more sense to me.